### PR TITLE
Update recordVoiceMessage script

### DIFF
--- a/addon/appModules/whatsapp.py
+++ b/addon/appModules/whatsapp.py
@@ -508,7 +508,7 @@ class AppModule(appModuleHandler.AppModule):
 	# Function of recording and sending a voice message
 	@script(description=_("Record and send a voice message"), gesture="kb:control+R")
 	def script_recordingVoiceMessage(self, gesture):
-		button = next((item for item in self.get_elements() if item.role == controlTypes.Role.BUTTON and controlTypes.State.FOCUSABLE in item.states and item.UIAAutomationId in ("RightButton", "PttSendButton")), None)
+		button = next((item for item in self.get_elements() if item.role == controlTypes.Role.BUTTON and controlTypes.State.FOCUSABLE in item.states and item.UIAAutomationId in ("RightButton", "PttSendButton", "SendVoiceMessageButton")), None)
 		if not button: return
 		if button.UIAAutomationId == "RightButton":
 			if button.firstChild.name == "\ue724":
@@ -524,6 +524,12 @@ class AppModule(appModuleHandler.AppModule):
 			button.doAction()
 			if config.conf["WhatsAppPlus"]['playSoundWhenRecordingVoiceMessage']:
 				playWaveFile(baseDir+"wa_ptt_sent.wav")
+		elif button.UIAAutomationId == "SendVoiceMessageButton":
+			self.is_skip_name = 2
+			button.doAction()
+			if config.conf["WhatsAppPlus"]['playSoundWhenRecordingVoiceMessage']:
+				playWaveFile(baseDir+"wa_ptt_sent.wav")
+
 
 	# Voice message discard function
 	@script(description=_("Discard voice message"), gesture="kb:control+D")


### PR DESCRIPTION
This commit updates the RecordVoiceMessage script due to a breaking change to the
UIA automation ID of the Send Voice Message button in WhatsApp v2.2402.1.0. It no longer is called
"pttSendButton," but is now called "SendVoiceMessageButton."
I have maintained backward compatibility with older versions, and have tested my modifications in my local copy of NVDA.
