### PR TITLE
Remove the update check mechanism for 2024 compatibility

### DIFF
--- a/addon/GlobalPlugins/WhatsAppPlus/__init__.py
+++ b/addon/GlobalPlugins/WhatsAppPlus/__init__.py
@@ -1,6 +1,4 @@
 ﻿# -*- coding: utf-8 -*-
-import api
-import IAccessibleHandler
 import globalPluginHandler
 import addonHandler
 from scriptHandler import script
@@ -8,7 +6,6 @@ import config
 import gui
 from gui import SettingsPanel, guiHelper, nvdaControls
 import wx
-import urllib.request
 import core
 import globalVars
 import os
@@ -20,11 +17,10 @@ from appModules.whatsapp import SPEC
 
 
 lang = languageHandler.getLanguage().split("_")[0]
-path_to_server = "http://46.254.107.124/addons/whatsappplus/"
 
 
 def getConfig(key):
-    return config.conf["WhatsAppPlus"][key]
+	return config.conf["WhatsAppPlus"][key]
 
 def setConfig(key, value):
 	config.conf["WhatsAppPlus"][key] = value
@@ -34,101 +30,8 @@ def setConfig(key, value):
 	except:
 		config.conf["WhatsAppPlus"][key] = value
 
-def no_updates_dialog():
-	res = gui.messageBox(
-		_("No updates available"),
-		_("WhatsAppPlus update"),
-		wx.OK | wx.ICON_INFORMATION)
-
-def onCheckForUpdates(event = False, is_start = False):
-	import versionInfo
-	NVDAVersion = f"{versionInfo.version_year}.{versionInfo.version_major}.{versionInfo.version_minor}"
-	NVDAVersion = int(NVDAVersion.replace(".", ""))
-	fp = os.path.join(globalVars.appArgs.configPath, "whatsappplus.nvda-addon")
-	addon_version = addonHandler.getCodeAddon().manifest["version"]
-	addon_version = int(addon_version.replace(".", ""))
-	try: response = urllib.request.urlopen(path_to_server+"version.txt").read().decode('utf-8')
-	except:
-		if not is_start: wx.CallAfter(no_updates_dialog)
-		return
-	response = str(response)
-	str_last_version = response.split("\n")[0]
-	last_version = int(str_last_version.replace(".", ""))
-	minimum_version = response.split("\n")[1]
-	minimum_version = int(minimum_version.replace(".", ""))
-	url = response.split("\n")[-1]
-	if last_version > addon_version and NVDAVersion >= minimum_version:
-		wx.CallAfter(window_for_update, None, str_last_version, url)
-	elif not is_start: wx.CallAfter(no_updates_dialog)
-
-class window_for_update(wx.Frame):
-	def __init__(self, parent, str_last_version, url):
-		title = _("WhatsAppPlus update")
-		text = _("A new version of the add-on is available. Do you want to update WhatsAppPlus to version %version?").replace("%version", str_last_version)
-		no_resize = wx.DEFAULT_FRAME_STYLE & ~ (wx.RESIZE_BORDER | wx.MAXIMIZE_BOX)
-		# wx.Frame.__init__(self, parent, title = title, size = (640, 360), style=no_resize)
-		wx.Frame.__init__(self, parent, title = title, size = (640, 360))
-		self.url = str(url)
-		self.str_last_version = str_last_version
-		self.Centre()
-		panel = wx.Panel(self)
-		self.text = wx.TextCtrl(panel, -1, text, style = wx.TE_MULTILINE | wx.TE_READONLY)
-		self.text.SetValue(text)
-		self.text.SetFocus()
-		self.button_ok = wx.Button(panel, label=_("Yes, update"))
-		self.button_close= wx.Button(panel, label=_("No, not now"))
-		self.button_ok.Bind(wx.EVT_BUTTON,self.download_update)
-		self.button_close.Bind(wx.EVT_BUTTON,self.window_close)
-		sizer = wx.BoxSizer(wx.VERTICAL)
-		buttons_sizer = wx.BoxSizer(wx.HORIZONTAL)
-		buttons_sizer.Add(self.button_ok, 0, wx.LEFT | wx.RIGHT, 5)
-		buttons_sizer.Add(self.button_close, 0, wx.LEFT | wx.RIGHT, 5)
-		sizer.Add(self.text, 1, wx.ALL | wx.EXPAND, 5)
-		sizer.Add(buttons_sizer, flag = wx.ALL | wx.ALIGN_RIGHT, border=5)
-		panel.SetSizer(sizer)
-		self.Raise()
-		self.Show(True)
-		self.get_documentation()
-
-	def download_update(self, event):
-		self.text.SetValue(_("Download in progress"))
-		self.text.SetFocus()
-		try: response_addon = urllib.request.urlopen(self.url).read()
-		except:
-			no_updates_dialog()
-			self.Close()
-			return
-		fp = os.path.join(globalVars.appArgs.configPath, "whatsappplus.nvda-addon")
-		with open(fp, 'wb') as addon:
-			addon.write(response_addon)
-		self.setup_update(fp)
-		self.button_ok.Disable()
-		self.button_close.Disable()
-
 	def window_close(self, event):
 		self.Close()
-	
-	def get_documentation(self):
-		doc = False
-		url = path_to_server+"documentation/"+self.str_last_version+"/"+lang+".txt"
-		try: doc = urllib.request.urlopen(url).read().decode('utf-8')
-		except: pass
-		try:
-			url = path_to_server+"documentation/"+self.str_last_version+"/en.txt"
-			if not doc: doc = urllib.request.urlopen(url).read().decode('utf-8')
-		except: pass
-		if doc: text = "\n"+_("Changes in this version:")+"\n"+str(doc)
-		else: text = "\n"+_(_("No update information"))
-		self.text.SetValue(self.text.GetValue()+text)
-
-	def setup_update(self, fp):
-		curAddons = addonHandler.getAvailableAddons()
-		bundle = addonHandler.AddonBundle(fp)
-		bundleName = bundle.manifest['name']
-		prevAddon = next((addon for addon in curAddons if not addon.isPendingRemove and bundleName == addon.manifest['name']), None)
-		if prevAddon: prevAddon.requestRemove()
-		addonHandler.installAddonBundle(bundle)
-		core.restart()
 
 
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
@@ -137,13 +40,6 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		super().__init__(*args, **kwargs)
 		config.conf.spec['WhatsAppPlus'] = SPEC
 		gui.settingsDialogs.NVDASettingsDialog.categoryClasses.append(WhatsAppPlusSettings)
-		# Check if the user folder contains a temporary add-on file, if so, then delete it
-		fp = os.path.join(globalVars.appArgs.configPath, "whatsappplus.nvda-addon")
-		if os.path.exists(fp): os.remove(fp)
-		# Checking for updates
-		obj = api.getFocusObject()
-		if config.conf["WhatsAppPlus"]["isAutomaticallyCheckForUpdates"] and not isinstance(obj, IAccessibleHandler.SecureDesktopNVDAObject):
-			threading.Thread(target=onCheckForUpdates, args=(False, True,)).start()
 
 	@script(description=_("Open WhatsAppPlus settings window"), gesture="kb:NVDA+control+W")
 	def script_open_settings_dialog(self, gesture, arg = False):
@@ -170,12 +66,6 @@ class WhatsAppPlusSettings(gui.SettingsPanel):
 		    self, label=_("Automatically report progress bar updates when focus is on a message")))
 		self.automatically_report_progress_indicators.SetValue(
 		    getConfig("automatically_report_progress_indicators"))
-		# Checking for Updates on NVDA Startup
-		self.is_automatically_check_for_updates = settingsSizerHelper.addItem(wx.CheckBox(self, label=_("Check for WhatsAppPlus updates on NVDA startup")))
-		self.is_automatically_check_for_updates.SetValue(getConfig("isAutomaticallyCheckForUpdates"))
-		# Button to check for updates
-		self.checkForUpdates = settingsSizerHelper.addItem(wx.Button(self, label=_("Check for &updates")))
-		self.checkForUpdates.Bind(wx.EVT_BUTTON, onCheckForUpdates)
 
 	def get_key(self, d, value):
 		for k, v in d.items():
@@ -189,7 +79,6 @@ class WhatsAppPlusSettings(gui.SettingsPanel):
 		self.phrases_of_unread_messages.Value = ",".join(phrases_of_unread_messages)
 		setConfig("phrasesOfUnreadMessages", self.phrases_of_unread_messages.Value)
 		setConfig("automatically_report_progress_indicators", self.automatically_report_progress_indicators.Value)
-		setConfig("isAutomaticallyCheckForUpdates", self.is_automatically_check_for_updates.IsChecked())
 		setConfig("playSoundWhenRecordingVoiceMessage", self.is_play_sound_when_recording_voice_message.IsChecked())
 
 	def onPanelActivated(self):

--- a/addon/appModules/whatsapp.py
+++ b/addon/appModules/whatsapp.py
@@ -61,7 +61,6 @@ SPEC = {
 	'phrasesOfUnreadMessages': 'string(default="'+phrases_of_unread_messages.get(lang, "en")+'")',
 	'number_phone': 'string(default="")',
 	'user_name': 'string(default="")',
-	'isAutomaticallyCheckForUpdates': 'boolean(default=True)',
 	'displayPhoneNumberInUsername': 'boolean(default=True)',
 	'automaticReadingOfNewMessages': 'boolean(default=False)',
 	'automatically_report_progress_indicators': 'boolean(default=False)',

--- a/buildVars.py
+++ b/buildVars.py
@@ -37,7 +37,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
 	"addon_minimumNVDAVersion": "2021.2.0",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2023.2",
+	"addon_lastTestedNVDAVersion": "2024.2",
 	# Add-on update channel (default is None, denoting stable releases,
 	# and for development releases, use "dev".)
 	# Do not change unless you know what you are doing!


### PR DESCRIPTION
Given the fact that this add-on is now in the add-on store (which supports add-on updates in a centralized way), this PR removes the add-on's native update checker in favour of the standard mechanism provided by the store. This also removes usage of the incompatible secure desktop API, allowing the add-on to be used with 2024 versions of NVDA.